### PR TITLE
Add package list command

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,8 +33,8 @@
 - [x] Add package domain
 - [x] Add YAML package file loader
 - [x] Add running `package validate [name]`
+- [x] Add running `package list`
 - [ ] Add running `package info [name]`
-- [ ] Add running `package list`
 
 ### Phase 4: Package Installation
 

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -1,10 +1,7 @@
 pub(crate) mod config;
 pub(crate) mod package;
 
-use comfy_table::{Row, Table};
-use selfie::{
-    config::AppConfig, progress_reporter::port::ProgressReporter, validation::ValidationIssue,
-};
+use selfie::{config::AppConfig, progress_reporter::port::ProgressReporter};
 use tracing::debug;
 
 use crate::cli::{ClapCommands, ConfigSubcommands, PackageSubcommands};
@@ -63,85 +60,6 @@ fn dispatch_config_command<R: ProgressReporter>(
 
     match command {
         ConfigSubcommands::Validate => config::handle_validate(&original_config, reporter),
-    }
-}
-
-struct TableReporter {
-    table: Table,
-}
-
-impl TableReporter {
-    fn new() -> Self {
-        use comfy_table::Table;
-
-        Self {
-            table: Table::new(),
-        }
-    }
-
-    fn setup(&mut self, header: Vec<&'static str>) -> &mut Self {
-        use comfy_table::{
-            ContentArrangement,
-            modifiers::{UTF8_ROUND_CORNERS, UTF8_SOLID_INNER_BORDERS},
-            presets::UTF8_FULL,
-        };
-        self.table
-            .load_preset(UTF8_FULL)
-            .apply_modifier(UTF8_ROUND_CORNERS)
-            .apply_modifier(UTF8_SOLID_INNER_BORDERS)
-            .set_content_arrangement(ContentArrangement::Dynamic)
-            .set_header(header);
-
-        self
-    }
-
-    fn add_errors(
-        &mut self,
-        error_issues: &[&ValidationIssue],
-        reporter: &impl ProgressReporter,
-    ) -> &mut Self {
-        for error in error_issues {
-            self.table.add_row(vec![
-                reporter.format_error(error.category().to_string()),
-                error.field().to_string(),
-                error.message().to_string(),
-                error
-                    .suggestion()
-                    .map(ToString::to_string)
-                    .unwrap_or_default(),
-            ]);
-        }
-
-        self
-    }
-
-    fn add_warnings(
-        &mut self,
-        warning_issues: &[&ValidationIssue],
-        reporter: &impl ProgressReporter,
-    ) -> &mut Self {
-        for warning in warning_issues {
-            self.table.add_row(vec![
-                reporter.format_warning(warning.category().to_string()),
-                warning.field().to_string(),
-                warning.message().to_string(),
-                warning
-                    .suggestion()
-                    .map(ToString::to_string)
-                    .unwrap_or_default(),
-            ]);
-        }
-
-        self
-    }
-
-    fn add_row<T: Into<Row>>(&mut self, row: T) -> &mut Self {
-        self.table.add_row(row);
-        self
-    }
-
-    fn print(&self) {
-        eprintln!("{}", &self.table);
     }
 }
 

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -1,7 +1,7 @@
 use selfie::{config::AppConfig, progress_reporter::port::ProgressReporter};
 use tracing::info;
 
-use crate::commands::{TableReporter, report_with_style};
+use crate::{commands::report_with_style, tables::ValidationTableReporter};
 
 pub(crate) fn handle_validate<R: ProgressReporter>(
     original_config: &AppConfig,
@@ -14,18 +14,18 @@ pub(crate) fn handle_validate<R: ProgressReporter>(
     if result.issues().has_errors() {
         reporter.report_error("Validation failed.");
 
-        let mut table_reporter = TableReporter::new();
+        let mut table_reporter = ValidationTableReporter::new();
         table_reporter
             .setup(vec!["Category", "Field", "Message", "Suggestion"])
-            .add_errors(&result.issues().errors(), &reporter)
-            .add_warnings(&result.issues().warnings(), &reporter)
+            .add_validation_errors(&result.issues().errors(), &reporter)
+            .add_validation_warnings(&result.issues().warnings(), &reporter)
             .print();
         1
     } else if result.issues().has_warnings() {
-        let mut table_reporter = TableReporter::new();
+        let mut table_reporter = ValidationTableReporter::new();
         table_reporter
             .setup(vec!["Category", "Field", "Message", "Suggestion"])
-            .add_warnings(&result.issues().warnings(), &reporter)
+            .add_validation_warnings(&result.issues().warnings(), &reporter)
             .print();
         0
     } else {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod commands;
 mod config;
+mod tables;
 
 use std::process;
 

--- a/crates/cli/src/tables.rs
+++ b/crates/cli/src/tables.rs
@@ -1,0 +1,106 @@
+use comfy_table::{
+    ContentArrangement, Row, Table, modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL_CONDENSED,
+};
+use selfie::{progress_reporter::port::ProgressReporter, validation::ValidationIssue};
+
+pub(crate) struct ValidationTableReporter {
+    table: Table,
+}
+
+impl ValidationTableReporter {
+    pub(crate) fn new() -> Self {
+        Self {
+            table: Table::new(),
+        }
+    }
+
+    pub(crate) fn setup(&mut self, header: Vec<&'static str>) -> &mut Self {
+        self.table
+            .load_preset(UTF8_FULL_CONDENSED)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_content_arrangement(ContentArrangement::Dynamic)
+            .set_header(header);
+
+        self
+    }
+
+    pub(crate) fn add_validation_errors(
+        &mut self,
+        error_issues: &[&ValidationIssue],
+        reporter: &impl ProgressReporter,
+    ) -> &mut Self {
+        for error in error_issues {
+            self.table.add_row(vec![
+                reporter.format_error(error.category().to_string()),
+                error.field().to_string(),
+                error.message().to_string(),
+                error
+                    .suggestion()
+                    .map(ToString::to_string)
+                    .unwrap_or_default(),
+            ]);
+        }
+
+        self
+    }
+
+    pub(crate) fn add_validation_warnings(
+        &mut self,
+        warning_issues: &[&ValidationIssue],
+        reporter: &impl ProgressReporter,
+    ) -> &mut Self {
+        for warning in warning_issues {
+            self.table.add_row(vec![
+                reporter.format_warning(warning.category().to_string()),
+                warning.field().to_string(),
+                warning.message().to_string(),
+                warning
+                    .suggestion()
+                    .map(ToString::to_string)
+                    .unwrap_or_default(),
+            ]);
+        }
+
+        self
+    }
+
+    pub(crate) fn add_row<T: Into<Row>>(&mut self, row: T) -> &mut Self {
+        self.table.add_row(row);
+        self
+    }
+
+    pub(crate) fn print(&self) {
+        eprintln!("{}", &self.table);
+    }
+}
+
+pub(crate) struct PackageListTableReporter {
+    table: Table,
+}
+
+impl PackageListTableReporter {
+    pub(crate) fn new() -> Self {
+        Self {
+            table: Table::new(),
+        }
+    }
+
+    pub(crate) fn setup(&mut self, header: Vec<&'static str>) -> &mut Self {
+        self.table
+            .load_preset(UTF8_FULL_CONDENSED)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_content_arrangement(ContentArrangement::Dynamic)
+            .set_header(header);
+
+        self
+    }
+
+    pub(crate) fn add_row<T: Into<Row>>(&mut self, row: T) -> &mut Self {
+        self.table.add_row(row);
+        self
+    }
+
+    pub(crate) fn print(&self) {
+        println!("{}", &self.table);
+    }
+}

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -139,6 +139,14 @@ fn test_cli_config_validate() {
 #[test]
 fn test_cli_package_list() {
     let temp_dir = setup_test_config();
+    let package = PackageBuilder::default()
+        .name("test-package")
+        .version("0.1.0")
+        .environment(SELFIE_ENV, |builder| builder.install("echo 'hi'"))
+        .build();
+
+    add_package(&temp_dir, &package);
+
     let mut cmd = get_command_with_test_config(&temp_dir);
     cmd.args(["package", "list"]);
     cmd.assert().success();

--- a/crates/cli/tests/package_list_tests.rs
+++ b/crates/cli/tests/package_list_tests.rs
@@ -1,0 +1,254 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use selfie::package::{Package, PackageBuilder};
+use std::{fs, io::Write};
+use tempfile::TempDir;
+
+const SELFIE_ENV: &str = "test-env";
+
+// Helper to create a temporary config environment
+fn setup_test_config() -> TempDir {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let config_dir = temp_dir.path().join(".config").join("selfie");
+    fs::create_dir_all(&config_dir).unwrap();
+
+    let config_path = config_dir.join("config.yaml");
+    let mut config_file = fs::File::create(&config_path).unwrap();
+
+    // Write minimal valid config
+    writeln!(config_file, "environment: {SELFIE_ENV}").unwrap();
+    writeln!(
+        config_file,
+        "package_directory: {}",
+        temp_dir.path().join("packages").display()
+    )
+    .unwrap();
+
+    temp_dir
+}
+
+// Helper to create YAML packages in the packages directory
+fn add_package(temp_dir: &TempDir, package: &Package) {
+    let packages_dir = temp_dir.path().join("packages");
+    fs::create_dir_all(&packages_dir).unwrap();
+
+    let package_path = packages_dir.join(format!("{}.yaml", package.name()));
+    let yaml = serde_yaml::to_string(package).unwrap();
+
+    fs::write(package_path, yaml).unwrap();
+}
+
+// Helper function to get a command instance with environment variables pointing to our test config
+fn get_command_with_test_config(temp_dir: &TempDir) -> Command {
+    let mut cmd = Command::cargo_bin("selfie-cli").unwrap();
+
+    // Override the config directory location
+    cmd.env(
+        "SELFIE_CONFIG_DIR",
+        temp_dir.path().join(".config").join("selfie"),
+    );
+
+    cmd
+}
+
+#[test]
+fn test_package_list_empty() {
+    // Test with no packages
+    let temp_dir = setup_test_config();
+    let packages_dir = temp_dir.path().join("packages");
+    fs::create_dir_all(&packages_dir).unwrap();
+
+    let mut cmd = get_command_with_test_config(&temp_dir);
+    cmd.args(["package", "list"]);
+
+    // Should succeed but not list any packages
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("No packages found."));
+}
+
+#[test]
+fn test_package_list_single_package() {
+    let temp_dir = setup_test_config();
+
+    // Create a single package
+    let package = PackageBuilder::default()
+        .name("test-package")
+        .version("1.0.0")
+        .environment(SELFIE_ENV, |b| b.install("echo 'Hello'"))
+        .build();
+
+    add_package(&temp_dir, &package);
+
+    let mut cmd = get_command_with_test_config(&temp_dir);
+    cmd.args(["package", "list"]);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("test-package"))
+        .stdout(predicate::str::contains("v1.0.0"));
+}
+
+#[test]
+fn test_package_list_multiple_packages() {
+    let temp_dir = setup_test_config();
+
+    // Create multiple packages
+    let packages = vec![
+        PackageBuilder::default()
+            .name("package-a")
+            .version("1.0.0")
+            .environment(SELFIE_ENV, |b| b.install("echo 'Install A'"))
+            .build(),
+        PackageBuilder::default()
+            .name("package-b")
+            .version("2.0.0")
+            .environment(SELFIE_ENV, |b| b.install("echo 'Install B'"))
+            .build(),
+        PackageBuilder::default()
+            .name("package-c")
+            .version("3.0.0")
+            .environment("other-env", |b| b.install("echo 'Install C'"))
+            .build(),
+    ];
+
+    for package in &packages {
+        add_package(&temp_dir, package);
+    }
+
+    let mut cmd = get_command_with_test_config(&temp_dir);
+    cmd.args(["package", "list"]);
+
+    // Should list all packages
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("package-a"))
+        .stdout(predicate::str::contains("package-b"))
+        .stdout(predicate::str::contains("package-c"))
+        .stdout(predicate::str::contains("v1.0.0"))
+        .stdout(predicate::str::contains("v2.0.0"))
+        .stdout(predicate::str::contains("v3.0.0"));
+}
+
+#[test]
+fn test_package_list_with_invalid_yaml() {
+    let temp_dir = setup_test_config();
+
+    // Create a valid package
+    let package = PackageBuilder::default()
+        .name("valid-package")
+        .version("1.0.0")
+        .environment(SELFIE_ENV, |b| b.install("echo 'Valid'"))
+        .build();
+
+    add_package(&temp_dir, &package);
+
+    // Add an invalid package file
+    let packages_dir = temp_dir.path().join("packages");
+    let invalid_path = packages_dir.join("invalid-package.yaml");
+    let invalid_yaml = r#"
+    name: "invalid-package"
+    version: 1.0.0
+    invalid_yaml: :::
+    "#;
+
+    fs::write(invalid_path, invalid_yaml).unwrap();
+
+    let mut cmd = get_command_with_test_config(&temp_dir);
+    cmd.args(["package", "list"]);
+
+    // Should show the valid package but report error for invalid one
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("valid-package"))
+        .stderr(predicate::str::contains("invalid-package.yaml"));
+}
+
+#[test]
+fn test_package_list_different_environments() {
+    let temp_dir = setup_test_config();
+
+    // Create packages with different environment configurations
+    let packages = vec![
+        // Package with current environment
+        PackageBuilder::default()
+            .name("current-env-package")
+            .version("1.0.0")
+            .environment(SELFIE_ENV, |b| b.install("echo 'Current'"))
+            .build(),
+        // Package with multiple environments including current
+        PackageBuilder::default()
+            .name("multi-env-package")
+            .version("2.0.0")
+            .environment(SELFIE_ENV, |b| b.install("echo 'Multi current'"))
+            .environment("other-env", |b| b.install("echo 'Multi other'"))
+            .build(),
+        // Package without the current environment
+        PackageBuilder::default()
+            .name("different-env-package")
+            .version("3.0.0")
+            .environment("other-env", |b| b.install("echo 'Different'"))
+            .build(),
+    ];
+
+    for package in &packages {
+        add_package(&temp_dir, package);
+    }
+
+    let mut cmd = get_command_with_test_config(&temp_dir);
+    cmd.args(["package", "list"]);
+
+    // Should show all packages, but mark current environment with *
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let output_str = String::from_utf8_lossy(&output);
+
+    // Verify current environment marking
+    assert!(output_str.contains("current-env-package"));
+    assert!(output_str.contains("multi-env-package"));
+    assert!(output_str.contains("different-env-package"));
+
+    // Current environments should be marked
+    assert!(output_str.contains(&format!("*{SELFIE_ENV}")));
+
+    // The "other-env" should be listed but not marked
+    assert!(output_str.contains("other-env"));
+}
+
+#[test]
+fn test_package_list_with_no_color_flag() {
+    let temp_dir = setup_test_config();
+
+    let package = PackageBuilder::default()
+        .name("test-package")
+        .version("1.0.0")
+        .environment(SELFIE_ENV, |b| b.install("echo 'Hello'"))
+        .build();
+
+    add_package(&temp_dir, &package);
+
+    let mut cmd = get_command_with_test_config(&temp_dir);
+    cmd.args(["--no-color", "package", "list"]);
+
+    // Should not contain ANSI color codes
+    let output = cmd.assert().success().get_output().stdout.clone();
+    let output_str = String::from_utf8_lossy(&output);
+    assert!(!output_str.contains("\x1B["), "Output: {output_str}");
+}
+
+#[test]
+fn test_package_list_non_existent_directory() {
+    let temp_dir = setup_test_config();
+
+    // Remove the packages directory that was created
+    let packages_dir = temp_dir.path().join("packages");
+    // fs::remove_dir_all(&packages_dir).unwrap();
+    fs::remove_dir_all(&packages_dir).ok();
+
+    let mut cmd = get_command_with_test_config(&temp_dir);
+    cmd.args(["package", "list"]);
+
+    // Should fail with appropriate error about missing directory
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Directory does not exist"));
+}

--- a/crates/selfie/src/config/validate.rs
+++ b/crates/selfie/src/config/validate.rs
@@ -32,6 +32,7 @@ impl ValidationResult {
 impl AppConfig {
     /// Full validation for the `AppConfig`
     ///
+    #[must_use]
     pub fn validate(&self) -> ValidationResult {
         let mut issues = Vec::new();
 
@@ -78,7 +79,7 @@ fn validate_package_directory(package_directory: &Path) -> Vec<ValidationIssue> 
             "package_directory",
             "The `package_directory` field exists, but has no value",
             Some("Set a value for `package_directory`. Ex. `package_directory: ~/dev/selfie-packages`")
-        ))
+        ));
     }
 
     // Validate the package directory path
@@ -92,7 +93,7 @@ fn validate_package_directory(package_directory: &Path) -> Vec<ValidationIssue> 
             "package_directory",
             "The path at `package_directory` exists, but cannot be expanded",
             Some("If the path is relative, simplify it, otherwise provide an absolute path"),
-        ))
+        ));
     }
 
     issues

--- a/crates/selfie/src/package.rs
+++ b/crates/selfie/src/package.rs
@@ -3,7 +3,7 @@ pub mod port;
 pub mod repository;
 pub mod validate;
 
-pub use self::builder::PackageBuilder;
+pub use self::builder::{EnvironmentConfigBuilder, PackageBuilder};
 
 // Core package entity and related types
 use std::{collections::HashMap, path::PathBuf};
@@ -53,14 +53,17 @@ pub struct EnvironmentConfig {
 }
 
 impl EnvironmentConfig {
+    #[must_use]
     pub fn install(&self) -> &str {
         &self.install
     }
 
+    #[must_use]
     pub fn check(&self) -> Option<&str> {
         self.check.as_deref()
     }
 
+    #[must_use]
     pub fn dependencies(&self) -> &[String] {
         &self.dependencies
     }

--- a/crates/selfie/src/package/builder.rs
+++ b/crates/selfie/src/package/builder.rs
@@ -87,11 +87,13 @@ impl EnvironmentConfigBuilder {
         self
     }
 
+    #[must_use]
     pub fn dependencies<T: ToString>(mut self, dependencies: Vec<T>) -> Self {
         self.dependencies = dependencies.into_iter().map(|d| d.to_string()).collect();
         self
     }
 
+    #[must_use]
     pub fn build(self) -> EnvironmentConfig {
         EnvironmentConfig {
             install: self.install,

--- a/crates/selfie/src/package/repository/yaml.rs
+++ b/crates/selfie/src/package/repository/yaml.rs
@@ -47,9 +47,16 @@ impl<'a, F: FileSystem> YamlPackageRepository<'a, F> {
         let content = self
             .fs
             .read_file(path)
-            .map_err(|e| PackageParseError::FileSystemError(e.to_string()))?;
+            .map_err(|e| PackageParseError::FileSystemError {
+                package_path: path.to_path_buf(),
+                source_message: e.to_string(),
+            })?;
 
-        let mut package: Package = serde_yaml::from_str(&content)?;
+        let mut package: Package =
+            serde_yaml::from_str(&content).map_err(|e| PackageParseError::YamlParse {
+                package_path: path.to_path_buf(),
+                source: e,
+            })?;
         package.path = path.to_path_buf();
 
         Ok(package)

--- a/crates/selfie/tests/package_repository_tests.rs
+++ b/crates/selfie/tests/package_repository_tests.rs
@@ -48,7 +48,10 @@ environments:
     assert_eq!(result.valid_packages().count(), 2);
 
     // Verify package names
-    let names: Vec<&str> = result.valid_packages().map(|p| p.name()).collect();
+    let names: Vec<&str> = result
+        .valid_packages()
+        .map(selfie::package::Package::name)
+        .collect();
     assert!(names.contains(&"package1"));
     assert!(names.contains(&"package2"));
 }


### PR DESCRIPTION
This pull request includes several changes to improve the validation and package listing functionalities in the CLI. The most important changes include the addition of `ValidationTableReporter` and `PackageListTableReporter` for better table reporting, and the implementation of the `package list` command.

### Improvements to table reporting:

* Added `ValidationTableReporter` and `PackageListTableReporter` for improved table reporting in `crates/cli/src/tables.rs`.
* Replaced `TableReporter` with `ValidationTableReporter` in `crates/cli/src/commands/config.rs` and `crates/cli/src/commands/package.rs`. [[1]](diffhunk://#diff-6c1ae9c7344a4bf3b1442b5bb5d8475d91f85b17b85f9b9c6df97102e7df221eL4-R4) [[2]](diffhunk://#diff-f204d117e60f16d8e373ce7f37aff71d793162c3d4a2b65e325247ede9608443L9-R15)

### Implementation of `package list` command:

* Implemented the `handle_list` function in `crates/cli/src/commands/package.rs` to list packages from the YAML package repository.

### Code cleanup:

* Removed the unused `TableReporter` struct and its methods from `crates/cli/src/commands.rs`.
* Updated imports to reflect the removal of `TableReporter` and addition of new table reporters. [[1]](diffhunk://#diff-8ca584402f97c4b247ce53751c880d2062b0e233444ab25771275c8982817a0dL4-R4) [[2]](diffhunk://#diff-f204d117e60f16d8e373ce7f37aff71d793162c3d4a2b65e325247ede9608443R1-R3)

### Miscellaneous:

* Marked the `package info` task as completed in `TODO.md`.
* Added a test for the `package list` command in `crates/cli/tests/cli_tests.rs`.