### PR TITLE
Add package check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# selfie-v4
+# selfie
+
+Selfie is a (meta) package manager that orchestrates package installations
+across different package managers and environments. It allows users to define
+their own package installation rules per environment, managing dependencies and
+providing clear feedback about installation progress.
+
+## Packages
+
+A Selfie package contains information about how you want to install that package
+on each of your environments. It lets you define some metadata about the
+package, plus commands for how to, in each given environment, a) `check` if the
+package is already installed, and b) how to install it. Selfie's CLI then
+provides commands to execute those commands in your environment.
+
+For example, if you have a package file for installing `ripgrep` that looks
+like:
+
+```yaml
+# packages/ripgrep.yaml
+---
+name: ripgrep
+version: 0.1.0
+homepage: https://github.com/BurntSushi/ripgrep
+description: ripgrep recursively searches directories for a regex pattern while respecting your gitignore
+
+environments:
+  macos:
+    install: brew install ripgrep
+    check: which rg
+    dependencies:
+      - homebrew
+  arch-linux:
+    install: sudo pacman -S ripgrep
+    check: which rg
+```
+
+...you've got yourself a Selfie package named `ripgrep` that you can install in
+any of two environments: `macos` and `arch-linux`.
+
+When you run `selfie package install ripgrep`, and your Selfie config file says
+your current environment is `macos`, then Selfie will:
+
+1. execute the `environments.macos.check` command to see if `ripgrep` is already
+   installed. If that returns `true`, Selfie's job is done, and it exits; if
+   not, it...
+2. does this same `check` and `install` process for each of the `dependencies`
+   its dependency tree, then...
+3. Executes the `environments.macos.install` command to install the package.
+
+As a note, you can also run `selfie package check ripgrep` to simply execute
+`environments.macos.check`.
+

--- a/TODO.md
+++ b/TODO.md
@@ -46,7 +46,11 @@
 
 ### Phase 4: Package Installation
 
+- [x] Add running `package check`
 - [ ] Add running `package install`
+  - [ ] Run `check` before install
+  - [ ] Run `install`
+  - [ ] Do this for all package dependencies
 
 ---
 

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -53,9 +53,17 @@ pub(crate) struct PackageCommands {
 
 #[derive(Subcommand, Debug, Clone)]
 pub(crate) enum PackageSubcommands {
-    /// Install a package
+    /// Run a package's `install` command
+    ///
     Install {
         /// Name of the package to install
+        package_name: String,
+    },
+
+    /// Run a package's `check` command
+    Check {
+        /// Name of the package to check
+        ///
         package_name: String,
     },
 

--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -49,6 +49,9 @@ async fn dispatch_package_command(
         PackageSubcommands::Install { package_name } => {
             package::install::handle_install(package_name, config, reporter)
         }
+        PackageSubcommands::Check { package_name } => {
+            package::check::handle_check(package_name, config, reporter).await
+        }
         PackageSubcommands::List => ListCommand::new(config, reporter).handle_command(),
         PackageSubcommands::Info { package_name } => {
             package::info::handle_info(package_name, config, reporter).await

--- a/crates/cli/src/commands/package.rs
+++ b/crates/cli/src/commands/package.rs
@@ -1,3 +1,4 @@
+pub(crate) mod check;
 pub(crate) mod create;
 pub(crate) mod info;
 pub(crate) mod install;

--- a/crates/cli/src/commands/package/check.rs
+++ b/crates/cli/src/commands/package/check.rs
@@ -1,0 +1,129 @@
+use selfie::{
+    commands::{ShellCommandRunner, runner::CommandRunner},
+    config::AppConfig,
+    fs::real::RealFileSystem,
+    package::{Package, port::PackageRepository, repository::YamlPackageRepository},
+};
+
+use crate::{
+    commands::package::handle_package_repo_error,
+    terminal_progress_reporter::TerminalProgressReporter,
+};
+
+pub(crate) async fn handle_check(
+    package_name: &str,
+    config: &AppConfig,
+    reporter: TerminalProgressReporter,
+) -> i32 {
+    tracing::debug!("Running check command for package: {}", package_name);
+
+    let repo = YamlPackageRepository::new(RealFileSystem, config.package_directory());
+    let command_runner = ShellCommandRunner::new("/bin/sh", config.command_timeout());
+
+    match repo.get_package(package_name) {
+        Ok(package) => {
+            execute_package_check(&package, package_name, config, &command_runner, reporter).await
+        }
+        Err(e) => {
+            handle_package_repo_error(e, &repo, reporter);
+            1
+        }
+    }
+}
+
+async fn execute_package_check(
+    package: &Package,
+    package_name: &str,
+    config: &AppConfig,
+    command_runner: &ShellCommandRunner,
+    reporter: TerminalProgressReporter,
+) -> i32 {
+    // Get the environment configuration for the current environment
+    let current_env = config.environment();
+
+    if let Some(env_config) = package.environments().get(current_env) {
+        if let Some(check_cmd) = env_config.check() {
+            execute_check_command(
+                package_name,
+                current_env,
+                check_cmd,
+                config,
+                command_runner,
+                reporter,
+            )
+            .await
+        } else {
+            // No check command defined for this environment
+            reporter.report_info(format!(
+                "No check command defined for package '{}' in environment '{}'",
+                package_name, current_env
+            ));
+            // Return success since there's no check command
+            0
+        }
+    } else {
+        // Environment not defined for this package
+        reporter.report_warning(format!(
+            "Package '{}' does not support environment '{}'",
+            package_name, current_env
+        ));
+        1
+    }
+}
+
+async fn execute_check_command(
+    package_name: &str,
+    environment: &str,
+    check_cmd: &str,
+    config: &AppConfig,
+    command_runner: &ShellCommandRunner,
+    reporter: TerminalProgressReporter,
+) -> i32 {
+    // Inform user what we're doing
+    reporter.report_info(format!(
+        "Checking package '{}' in environment '{}'",
+        package_name, environment
+    ));
+
+    // Run the check command
+    match command_runner
+        .execute_with_timeout(check_cmd, config.command_timeout())
+        .await
+    {
+        Ok(output) => process_command_output(output, package_name, config, reporter),
+        Err(error) => {
+            reporter.report_error(format!("Failed to execute check command: {}", error));
+            1
+        }
+    }
+}
+
+fn process_command_output(
+    output: selfie::commands::runner::CommandOutput,
+    package_name: &str,
+    config: &AppConfig,
+    reporter: TerminalProgressReporter,
+) -> i32 {
+    // If verbose mode is enabled, print the command output
+    if config.verbose() {
+        if !output.stdout_str().trim().is_empty() {
+            println!("{}", output.stdout_str());
+        }
+        if !output.stderr_str().trim().is_empty() {
+            eprintln!("{}", output.stderr_str());
+        }
+    }
+
+    // Return success/failure based on the command's exit code
+    if output.is_success() {
+        reporter.report_success(format!("Package '{}' is installed", package_name));
+        0
+    } else {
+        reporter.report_info(format!(
+            "Package '{}' not installed (exit code: {})",
+            package_name,
+            output.exit_code()
+        ));
+        output.exit_code()
+    }
+}

--- a/crates/cli/src/commands/package/info.rs
+++ b/crates/cli/src/commands/package/info.rs
@@ -9,6 +9,7 @@ use selfie::{
 
 use crate::{
     commands::package::handle_package_repo_error,
+    formatters::{self, FieldStyle},
     terminal_progress_reporter::TerminalProgressReporter,
 };
 
@@ -24,184 +25,26 @@ pub(crate) async fn handle_info(
 
     match repo.get_package(package_name) {
         Ok(package) => {
-            // Create main table for package metadata
-            let mut table = Table::new();
-
-            table
-                .load_preset(presets::UTF8_FULL_CONDENSED)
-                .apply_modifier(modifiers::UTF8_ROUND_CORNERS)
-                .set_content_arrangement(ContentArrangement::Dynamic);
-
             // Helper function for formatting field names in the left column
             let format_field = |name: &str| -> String {
-                if config.use_colors() {
-                    style(name).bold().cyan().to_string()
-                } else {
-                    style(name).bold().to_string()
-                }
+                formatters::format_field(name, FieldStyle::Key, config.use_colors())
             };
 
             // Helper function for formatting values in the right column
             let format_value = |value: &str| -> String {
-                if config.use_colors() {
-                    style(value).white().to_string()
-                } else {
-                    value.to_string()
-                }
+                formatters::format_field(value, FieldStyle::Value, config.use_colors())
             };
 
-            // Add the basic package info rows
-            table.add_row(vec![format_field("Name"), format_value(package.name())]);
-            table.add_row(vec![
-                format_field("Version"),
-                format_value(package.version()),
-            ]);
-
-            if let Some(desc) = package.description() {
-                table.add_row(vec![format_field("Description"), format_value(desc)]);
-            }
-
-            if let Some(homepage) = package.homepage() {
-                table.add_row(vec![
-                    format_field("Homepage"),
-                    if config.use_colors() {
-                        style(homepage).underlined().blue().to_string()
-                    } else {
-                        homepage.to_string()
-                    },
-                ]);
-            }
-
-            // Format the environment names as a comma-separated list
-            let env_names = package
-                .environments()
-                .keys()
-                .map(|name| {
-                    if name == config.environment() {
-                        if config.use_colors() {
-                            format!("{}", style(format!("*{name}")).green().bold())
-                        } else {
-                            format!("*{name}")
-                        }
-                    } else {
-                        name.to_string()
-                    }
-                })
-                .collect::<Vec<_>>()
-                .join(", ");
-
-            // Add environments row with list of environment names
-            table.add_row(vec![format_field("Environments"), format_value(&env_names)]);
-
-            // Print the main table
+            // Create and display main package info table
+            let table = create_package_info_table(&package, config, format_field, format_value);
             println!("{table}");
-
             println!(); // Space between tables
 
-            // For each environment, create a separate table with header
-            for (env_name, env_config) in package.environments() {
-                // Create environment details table
-                let mut env_table = Table::new();
-                env_table
-                    .load_preset(presets::UTF8_FULL_CONDENSED)
-                    .apply_modifier(modifiers::UTF8_ROUND_CORNERS)
-                    .set_content_arrangement(ContentArrangement::Dynamic);
-
-                // Create a header for the environment table
-                let env_header = if env_name == config.environment() {
-                    let msg = format!("Environment: *{env_name}");
-                    if config.use_colors() {
-                        style(msg).bold().green().to_string()
-                    } else {
-                        msg
-                    }
-                } else {
-                    let msg = format!("Environment: {env_name}");
-                    if config.use_colors() {
-                        style(msg).bold().to_string()
-                    } else {
-                        msg
-                    }
-                };
-
-                // Add a header row
-                env_table.set_header(vec![env_header, String::new()]);
-
-                // Format environment detail keys
-                let format_env_key = |key: &str| -> String {
-                    if config.use_colors() {
-                        style(key).magenta().to_string()
-                    } else {
-                        key.to_string()
-                    }
-                };
-
-                // Add installation status if this is the current environment
-                if env_name == config.environment() {
-                    // Only run check for current environment
-                    if let Some(check_cmd) = env_config.check() {
-                        // Run the check command asynchronously
-                        if let Ok(output) = command_runner.execute(check_cmd).await {
-                            let status = if output.is_success() {
-                                if config.use_colors() {
-                                    style("Installed ✓").green().bold().to_string()
-                                } else {
-                                    "Installed ✓".to_string()
-                                }
-                            } else if config.use_colors() {
-                                style("Not installed ✗").yellow().to_string()
-                            } else {
-                                "Not installed ✗".to_string()
-                            };
-
-                            env_table.add_row(vec![format_env_key("Status"), status]);
-                        } else {
-                            // Error executing check command
-                            let status = if config.use_colors() {
-                                style("Unknown (check failed)")
-                                    .yellow()
-                                    .italic()
-                                    .to_string()
-                            } else {
-                                "Unknown (check failed)".to_string()
-                            };
-
-                            env_table.add_row(vec![format_env_key("Status"), status]);
-                        }
-                    } else {
-                        // No check command available
-                        let status = if config.use_colors() {
-                            style("Unknown (no check command)")
-                                .dim()
-                                .italic()
-                                .to_string()
-                        } else {
-                            "Unknown (no check command)".to_string()
-                        };
-
-                        env_table.add_row(vec![format_env_key("Status"), status]);
-                    }
-                }
-
-                // Add environment detail rows
-                env_table.add_row(vec![
-                    format_env_key("Install"),
-                    format_value(env_config.install()),
-                ]);
-
-                if let Some(check) = env_config.check() {
-                    env_table.add_row(vec![format_env_key("Check"), format_value(check)]);
-                }
-
-                if !env_config.dependencies().is_empty() {
-                    env_table.add_row(vec![
-                        format_env_key("Dependencies"),
-                        format_value(&env_config.dependencies().join(", ")),
-                    ]);
-                }
-
-                // Print the environment details table
-                println!("{env_table}");
+            // Create and display environment tables
+            let env_tables =
+                create_environment_tables(&package, config, &command_runner, format_value).await;
+            for table in env_tables {
+                println!("{table}");
                 println!(); // Add space between environment tables
             }
 
@@ -209,10 +52,196 @@ pub(crate) async fn handle_info(
         }
         Err(e) => {
             let repo: &dyn PackageRepository = &repo;
-
             handle_package_repo_error(e, repo, reporter);
-
             1
+        }
+    }
+}
+
+fn create_package_info_table<F, V>(
+    package: &selfie::package::Package,
+    config: &AppConfig,
+    format_field: F,
+    format_value: V,
+) -> Table
+where
+    F: Fn(&str) -> String,
+    V: Fn(&str) -> String,
+{
+    let mut table = create_table();
+
+    // Add the basic package info rows
+    table.add_row(vec![format_field("Name"), format_value(package.name())]);
+    table.add_row(vec![
+        format_field("Version"),
+        format_value(package.version()),
+    ]);
+
+    if let Some(desc) = package.description() {
+        table.add_row(vec![format_field("Description"), format_value(desc)]);
+    }
+
+    if let Some(homepage) = package.homepage() {
+        table.add_row(vec![
+            format_field("Homepage"),
+            if config.use_colors() {
+                style(homepage).underlined().blue().to_string()
+            } else {
+                homepage.to_string()
+            },
+        ]);
+    }
+
+    // Format the environment names as a comma-separated list
+    let env_names = format_environment_names(package, config);
+
+    // Add environments row with list of environment names
+    table.add_row(vec![format_field("Environments"), format_value(&env_names)]);
+
+    table
+}
+
+fn create_table() -> Table {
+    let mut table = Table::new();
+    table
+        .load_preset(presets::UTF8_FULL_CONDENSED)
+        .apply_modifier(modifiers::UTF8_ROUND_CORNERS)
+        .set_content_arrangement(ContentArrangement::Dynamic);
+    table
+}
+
+fn format_environment_names(package: &selfie::package::Package, config: &AppConfig) -> String {
+    package
+        .environments()
+        .keys()
+        .map(|name| {
+            if name == config.environment() {
+                if config.use_colors() {
+                    format!("{}", style(format!("*{name}")).green().bold())
+                } else {
+                    format!("*{name}")
+                }
+            } else {
+                name.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+async fn create_environment_tables<V>(
+    package: &selfie::package::Package,
+    config: &AppConfig,
+    command_runner: &ShellCommandRunner,
+    format_value: V,
+) -> Vec<Table>
+where
+    V: Fn(&str) -> String,
+{
+    let mut tables = Vec::new();
+
+    for (env_name, env_config) in package.environments() {
+        // Create environment details table
+        let mut env_table = create_table();
+
+        // Create a header for the environment table
+        let env_header = if env_name == config.environment() {
+            let msg = format!("Environment: *{env_name}");
+            if config.use_colors() {
+                style(msg).bold().green().to_string()
+            } else {
+                msg
+            }
+        } else {
+            let msg = format!("Environment: {env_name}");
+            if config.use_colors() {
+                style(msg).bold().to_string()
+            } else {
+                msg
+            }
+        };
+
+        // Add a header row
+        env_table.set_header(vec![env_header, String::new()]);
+
+        // Format environment detail keys
+        let format_env_key = |key: &str| -> String {
+            if config.use_colors() {
+                style(key).magenta().to_string()
+            } else {
+                key.to_string()
+            }
+        };
+
+        // Add installation status if this is the current environment
+        if env_name == config.environment() {
+            let status =
+                get_installation_status(env_config, command_runner, config.use_colors()).await;
+            env_table.add_row(vec![format_env_key("Status"), status]);
+        }
+
+        // Add environment detail rows
+        env_table.add_row(vec![
+            format_env_key("Install"),
+            format_value(env_config.install()),
+        ]);
+
+        if let Some(check) = env_config.check() {
+            env_table.add_row(vec![format_env_key("Check"), format_value(check)]);
+        }
+
+        if !env_config.dependencies().is_empty() {
+            env_table.add_row(vec![
+                format_env_key("Dependencies"),
+                format_value(&env_config.dependencies().join(", ")),
+            ]);
+        }
+
+        tables.push(env_table);
+    }
+
+    tables
+}
+async fn get_installation_status(
+    env_config: &selfie::package::EnvironmentConfig,
+    command_runner: &ShellCommandRunner,
+    use_colors: bool,
+) -> String {
+    // Only run check for current environment
+    if let Some(check_cmd) = env_config.check() {
+        // Run the check command asynchronously
+        if let Ok(output) = command_runner.execute(check_cmd).await {
+            if output.is_success() {
+                if use_colors {
+                    style("Installed ✓").green().bold().to_string()
+                } else {
+                    "Installed ✓".to_string()
+                }
+            } else if use_colors {
+                style("Not installed ✗").yellow().to_string()
+            } else {
+                "Not installed ✗".to_string()
+            }
+        } else {
+            // Error executing check command
+            if use_colors {
+                style("Unknown (check failed)")
+                    .yellow()
+                    .italic()
+                    .to_string()
+            } else {
+                "Unknown (check failed)".to_string()
+            }
+        }
+    } else {
+        // No check command available
+        if use_colors {
+            style("Unknown (no check command)")
+                .dim()
+                .italic()
+                .to_string()
+        } else {
+            "Unknown (no check command)".to_string()
         }
     }
 }

--- a/crates/cli/src/commands/package/list.rs
+++ b/crates/cli/src/commands/package/list.rs
@@ -22,6 +22,103 @@ impl<'a> ListCommand<'a> {
     pub(crate) fn new(config: &'a AppConfig, reporter: TerminalProgressReporter) -> Self {
         Self { config, reporter }
     }
+
+    fn handle_packages_output(
+        &self,
+        list_packages_output: selfie::package::port::ListPackagesOutput,
+    ) -> i32 {
+        let sorted_errors = self.get_sorted_errors(&list_packages_output);
+        let sorted_packages = self.get_sorted_packages(&list_packages_output);
+
+        if sorted_packages.is_empty() {
+            self.report_no_packages_found(&sorted_errors);
+            return 0;
+        }
+
+        self.display_packages_table(&sorted_packages);
+        self.report_invalid_packages(&sorted_errors);
+        0
+    }
+
+    fn get_sorted_errors<'b>(
+        &self,
+        output: &'b selfie::package::port::ListPackagesOutput,
+    ) -> Vec<&'b selfie::package::port::PackageParseError> {
+        let mut sorted_errors: Vec<_> = output.invalid_packages().collect();
+        sorted_errors.sort_by(|a, b| a.package_path().cmp(b.package_path()));
+        sorted_errors
+    }
+
+    fn get_sorted_packages<'b>(
+        &self,
+        output: &'b selfie::package::port::ListPackagesOutput,
+    ) -> Vec<&'b selfie::package::Package> {
+        let mut sorted_packages: Vec<_> = output.valid_packages().collect();
+        sorted_packages.sort_by(|a, b| a.name().cmp(b.name()));
+        sorted_packages
+    }
+
+    fn report_no_packages_found(&self, errors: &[&selfie::package::port::PackageParseError]) {
+        self.reporter.report_info("No packages found.");
+        self.report_invalid_packages(errors);
+    }
+
+    fn report_invalid_packages(&self, errors: &[&selfie::package::port::PackageParseError]) {
+        for error in errors {
+            self.reporter
+                .report_error(format!("{}: {}", error.package_path().display(), error));
+        }
+    }
+
+    fn display_packages_table(&self, packages: &[&selfie::package::Package]) {
+        let mut package_reporter = PackageListTableReporter::new();
+        package_reporter.setup(vec!["Name", "Version", "Environments"]);
+
+        for package in packages {
+            package_reporter.add_row(self.format_package_row(package));
+        }
+
+        package_reporter.print();
+    }
+
+    fn format_package_row(&self, package: &selfie::package::Package) -> Vec<String> {
+        let package_name = if self.config.use_colors() {
+            style(package.name()).magenta().bold().to_string()
+        } else {
+            package.name().to_string()
+        };
+
+        let version = if self.config.use_colors() {
+            style(format!("v{}", package.version())).dim().to_string()
+        } else {
+            format!("v{}", package.version())
+        };
+
+        vec![package_name, version, self.format_environments(package)]
+    }
+
+    fn format_environments(&self, package: &selfie::package::Package) -> String {
+        package
+            .environments()
+            .keys()
+            .map(|env_name| {
+                if env_name == self.config.environment() {
+                    let env = format!("*{env_name}");
+
+                    if self.config.use_colors() {
+                        style(env).bold().green().to_string()
+                    } else {
+                        env
+                    }
+                } else if self.config.use_colors() {
+                    style(env_name).dim().green().to_string()
+                } else {
+                    env_name.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(",  ")
+    }
 }
 
 impl HandleCommand for ListCommand<'_> {
@@ -29,81 +126,7 @@ impl HandleCommand for ListCommand<'_> {
         let repo = YamlPackageRepository::new(RealFileSystem, self.config.package_directory());
 
         match repo.list_packages() {
-            Ok(list_packages_output) => {
-                let mut sorted_errors: Vec<_> = list_packages_output.invalid_packages().collect();
-                sorted_errors.sort_by(|a, b| a.package_path().cmp(b.package_path()));
-
-                let mut sorted_packages: Vec<_> = list_packages_output.valid_packages().collect();
-                sorted_packages.sort_by(|a, b| a.name().cmp(b.name()));
-
-                if sorted_packages.is_empty() {
-                    self.reporter.report_info("No packages found.");
-
-                    for error in sorted_errors {
-                        self.reporter.report_error(format!(
-                            "{}: {}",
-                            error.package_path().display(),
-                            error
-                        ));
-                    }
-
-                    return 0;
-                }
-
-                let mut package_reporter = PackageListTableReporter::new();
-                package_reporter.setup(vec!["Name", "Version", "Environments"]);
-
-                for package in sorted_packages {
-                    let package_name = if self.config.use_colors() {
-                        style(package.name()).magenta().bold().to_string()
-                    } else {
-                        package.name().to_string()
-                    };
-
-                    let version = if self.config.use_colors() {
-                        style(format!("v{}", package.version())).dim().to_string()
-                    } else {
-                        format!("v{}", package.version())
-                    };
-
-                    package_reporter.add_row(vec![
-                        package_name,
-                        version,
-                        package
-                            .environments()
-                            .keys()
-                            .map(|env_name| {
-                                if env_name == self.config.environment() {
-                                    let env = format!("*{env_name}");
-
-                                    if self.config.use_colors() {
-                                        style(env).bold().green().to_string()
-                                    } else {
-                                        env
-                                    }
-                                } else if self.config.use_colors() {
-                                    style(env_name).dim().green().to_string()
-                                } else {
-                                    env_name.to_string()
-                                }
-                            })
-                            .collect::<Vec<_>>()
-                            .join(",  "),
-                    ]);
-                }
-
-                package_reporter.print();
-
-                for error in sorted_errors {
-                    self.reporter.report_error(format!(
-                        "{}: {}",
-                        error.package_path().display(),
-                        error
-                    ));
-                }
-
-                0
-            }
+            Ok(list_packages_output) => self.handle_packages_output(list_packages_output),
             Err(e) => {
                 PackageListErrorReporter::new(e, self.reporter).report_error();
                 1

--- a/crates/cli/src/commands/package/validate.rs
+++ b/crates/cli/src/commands/package/validate.rs
@@ -1,10 +1,10 @@
 use std::fmt::Display;
 
-use console::style;
 use selfie::{
     config::AppConfig,
     fs::real::RealFileSystem,
     package::{port::PackageRepository, repository::YamlPackageRepository},
+    validation::ValidationIssues,
 };
 
 use crate::{
@@ -18,13 +18,6 @@ pub(crate) fn handle_validate(
     config: &AppConfig,
     reporter: TerminalProgressReporter,
 ) -> i32 {
-    fn format_table_key<T: Display>(key: T, use_colors: bool) -> String {
-        if use_colors {
-            style(key).magenta().bold().to_string()
-        } else {
-            key.to_string()
-        }
-    }
     reporter.report_info(format!(
         "Validating package '{}' in environment: {}",
         package_name,
@@ -36,60 +29,87 @@ pub(crate) fn handle_validate(
     match repo.get_package(package_name) {
         Ok(package) => {
             let validation_result = package.validate(config.environment());
+            let issues = validation_result.issues();
 
-            if validation_result.issues().has_errors() {
-                reporter.report_error("Validation failed.");
-
-                let mut table_reporter = ValidationTableReporter::new();
-                table_reporter
-                    .setup(vec!["Category", "Field", "Message", "Suggestion"])
-                    .add_validation_errors(&validation_result.issues().errors(), &reporter)
-                    .add_validation_warnings(&validation_result.issues().warnings(), &reporter)
-                    .print();
-                1
-            } else if validation_result.issues().has_warnings() {
-                let mut table_reporter = ValidationTableReporter::new();
-                table_reporter
-                    .setup(vec!["Category", "Field", "Message", "Suggestion"])
-                    .add_validation_warnings(&validation_result.issues().warnings(), &reporter)
-                    .print();
-                0
+            if issues.has_errors() {
+                handle_validation_errors(issues, &reporter)
+            } else if issues.has_warnings() {
+                handle_validation_warnings(issues, &reporter)
             } else {
-                reporter.report_success("Package is valid.");
-
-                report_with_style("name:", package.name());
-                report_with_style("version:", package.version());
-                report_with_style("homepage:", package.homepage().unwrap_or_default());
-                report_with_style("description:", package.description().unwrap_or_default());
-                report_with_style("environments:", "");
-
-                for (name, env_config) in package.environments() {
-                    report_with_style(format!("- {name}"), "");
-
-                    let mut env_table = ValidationTableReporter::new();
-                    env_table.setup(vec!["Key", "Value"]);
-
-                    let install_key = format_table_key("install", config.use_colors());
-                    let check_key = format_table_key("check", config.use_colors());
-                    let dependencies_key = format_table_key("dependencies", config.use_colors());
-
-                    env_table.add_row(vec![&install_key, env_config.install()]);
-                    env_table.add_row(vec![&check_key, env_config.check().unwrap_or_default()]);
-                    env_table.add_row(vec![
-                        &dependencies_key,
-                        &env_config.dependencies().join(", "),
-                    ]);
-                    env_table.print();
-                }
-
-                0
+                display_valid_package_info(&package, config, &reporter)
             }
         }
         Err(e) => {
             let repo: &dyn PackageRepository = &repo;
-
             PackageRepoErrorReporter::new(e, repo, reporter).report_error();
             1
         }
+    }
+}
+
+fn format_table_key<T: Display>(key: T, use_colors: bool) -> String {
+    use crate::formatters::{FieldStyle, format_field};
+    format_field(key, FieldStyle::Title, use_colors)
+}
+
+fn handle_validation_errors(issues: &ValidationIssues, reporter: &TerminalProgressReporter) -> i32 {
+    reporter.report_error("Validation failed.");
+
+    let mut table_reporter = ValidationTableReporter::new();
+    table_reporter
+        .setup(vec!["Category", "Field", "Message", "Suggestion"])
+        .add_validation_errors(&issues.errors(), reporter)
+        .add_validation_warnings(&issues.warnings(), reporter)
+        .print();
+    1
+}
+
+fn handle_validation_warnings(
+    issues: &ValidationIssues,
+    reporter: &TerminalProgressReporter,
+) -> i32 {
+    let mut table_reporter = ValidationTableReporter::new();
+    table_reporter
+        .setup(vec!["Category", "Field", "Message", "Suggestion"])
+        .add_validation_warnings(&issues.warnings(), reporter)
+        .print();
+    0
+}
+
+fn display_valid_package_info(
+    package: &selfie::package::Package,
+    config: &AppConfig,
+    reporter: &TerminalProgressReporter,
+) -> i32 {
+    reporter.report_success("Package is valid.");
+
+    report_with_style("name:", package.name());
+    report_with_style("version:", package.version());
+    report_with_style("homepage:", package.homepage().unwrap_or_default());
+    report_with_style("description:", package.description().unwrap_or_default());
+    report_with_style("environments:", "");
+
+    display_environments(package, config);
+    0
+}
+
+fn display_environments(package: &selfie::package::Package, config: &AppConfig) {
+    for (name, env_config) in package.environments() {
+        report_with_style(format!("- {name}"), "");
+
+        let mut env_table = ValidationTableReporter::new();
+        env_table.setup(vec!["Key", "Value"]);
+
+        let install_key = format_table_key("install", config.use_colors());
+        let check_key = format_table_key("check", config.use_colors());
+        let dependencies_key = format_table_key("dependencies", config.use_colors());
+
+        env_table.add_row(vec![&install_key, env_config.install()]);
+        env_table.add_row(vec![&check_key, env_config.check().unwrap_or_default()]);
+        env_table.add_row(vec![
+            &dependencies_key,
+            &env_config.dependencies().join(", "),
+        ]);
+        env_table.print();
     }
 }

--- a/crates/cli/src/formatters.rs
+++ b/crates/cli/src/formatters.rs
@@ -1,0 +1,39 @@
+//! Shared text formatting utilities for consistent styling
+
+use console::style;
+use std::fmt::Display;
+
+/// Styling options for different field types
+pub(crate) enum FieldStyle {
+    Key,   // Table keys, field names
+    Value, // Values in tables/output
+    Title, // Section titles
+    Custom(fn(console::StyledObject<String>) -> console::StyledObject<String>),
+}
+
+/// Format text with consistent styling based on field type
+pub(crate) fn format_field<T: Display>(
+    text: T,
+    style_type: FieldStyle,
+    use_colors: bool,
+) -> String {
+    let text = text.to_string();
+
+    // Apply bold styling regardless of colors for keys and titles
+    let styled = match style_type {
+        FieldStyle::Key | FieldStyle::Title => style(text).bold(),
+        _ => style(text),
+    };
+
+    if !use_colors {
+        return styled.to_string();
+    }
+
+    // Apply color styling
+    match style_type {
+        FieldStyle::Key => styled.cyan().to_string(),
+        FieldStyle::Value => styled.white().to_string(),
+        FieldStyle::Title => styled.magenta().to_string(),
+        FieldStyle::Custom(styler) => styler(styled).to_string(),
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod commands;
 mod config;
+mod formatters;
 mod tables;
 mod terminal_progress_reporter;
 

--- a/crates/cli/tests/cli_tests.rs
+++ b/crates/cli/tests/cli_tests.rs
@@ -118,6 +118,22 @@ fn test_cli_package_info() {
 }
 
 #[test]
+fn test_cli_package_check() {
+    let temp_dir = setup_default_test_config();
+    let package = PackageBuilder::default()
+        .name("test-package")
+        .version("0.1.0")
+        .environment(SELFIE_ENV, |builder| builder.install("echo 'hi'"))
+        .build();
+
+    add_package(&temp_dir, &package);
+
+    let mut cmd = get_command_with_test_config(&temp_dir);
+    cmd.args(["package", "check", "test-package"]);
+    cmd.assert().success();
+}
+
+#[test]
 fn test_cli_package_install() {
     let temp_dir = setup_default_test_config();
     let mut cmd = get_command_with_test_config(&temp_dir);


### PR DESCRIPTION
This pull request introduces a new `check` command to the Selfie CLI, enhances the documentation to explain the tool's functionality, and updates the test suite to cover the new feature. The most significant changes include the implementation of the `check` command, updates to the README to describe Selfie's capabilities, and the addition of a test for the `check` command.

### New Feature: `check` Command

* Added a new `check` subcommand to the `PackageSubcommands` enum in `crates/cli/src/cli.rs`, allowing users to verify if a package is installed in the current environment (`[crates/cli/src/cli.rsL56-R69](diffhunk://#diff-35706f1a95de3e24e5dad68242253e465d5190596622bd63719b16d29500851aL56-R69)`).
* Implemented the `handle_check` function in `crates/cli/src/commands/package/check.rs` to execute the `check` command for a package, including handling environment-specific configurations and reporting results (`[crates/cli/src/commands/package/check.rsR1-R101](diffhunk://#diff-8d891a3738f40a9b3f79d849fdb6ff839d43a37b894485ac48877df5e733c3afR1-R101)`).
* Updated the `dispatch_package_command` function in `crates/cli/src/commands.rs` to handle the `check` subcommand (`[crates/cli/src/commands.rsR52-R54](diffhunk://#diff-8ca584402f97c4b247ce53751c880d2062b0e233444ab25771275c8982817a0dR52-R54)`).

### Documentation Updates

* Updated the `README.md` file to provide an overview of Selfie, its purpose, and an example of defining and using a package configuration (`[README.mdL1-R53](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R53)`).

### Test Suite Enhancements

* Added a new test, `test_cli_package_check`, in `crates/cli/tests/cli_tests.rs` to validate the functionality of the `check` command (`[crates/cli/tests/cli_tests.rsR120-R135](diffhunk://#diff-dc7fac414aaaf62af559db7d1f684648172a7a8372c238d11be2d619911cd122R120-R135)`).

### Miscellaneous

* Updated the `TODO.md` file to include tasks related to running the `check` command before `install` and handling dependencies (`[TODO.mdR49-R53](diffhunk://#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986R49-R53)`).
* Added a new module for the `check` command in `crates/cli/src/commands/package.rs` (`[crates/cli/src/commands/package.rsR1](diffhunk://#diff-f204d117e60f16d8e373ce7f37aff71d793162c3d4a2b65e325247ede9608443R1)`).